### PR TITLE
fix(about): change ‘Stracker’ to ‘Tracker’

### DIFF
--- a/www/about.html
+++ b/www/about.html
@@ -26,7 +26,7 @@
     <main>
       <a href="/">← Return to the tracker</a>
       <h2>About</h2>
-      <p>Stracker is a concise and small application intended to help you get started with Hoodie. It's a basic tracker of all sorts. The mechanics let you keep track of anything you want plus its amount.</p>
+      <p>Tracker is a concise and small application intended to help you get started with Hoodie. It's a basic tracker of all sorts. The mechanics let you keep track of anything you want plus its amount.</p>
     </main>
 
     <script src="/hoodie/client.js"></script>


### PR DESCRIPTION
I changed 'Stracker' to 'Tracker' in the about page as _everything_ else refers to it as 'Tracker', not 'Stracker'.

:sun_with_face: 