### PR TITLE
wip: offline version

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -56,5 +56,13 @@
     <script src="/hoodie/client.js"></script>
     <script src="assets/js/common.js"></script>
     <script src="assets/js/index.js"></script>
+    <script>
+      // Let's register our service worker
+            navigator.serviceWorker.register('sw.js', {
+        // The scope cannot be parent to the script url
+        scope: './'
+      });
+    </script>
+    <script src="logging.js"></script>
   </body>
 </html>

--- a/public/logging.js
+++ b/public/logging.js
@@ -1,0 +1,41 @@
+// First time playing with SW? This script is just for logging,
+// you can pretty much ignore it until you want to dive deeper.
+
+if (!navigator.serviceWorker.controller) {
+  console.log("This page is not controlled by a ServiceWorker");
+}
+else {
+  console.log("This page is controlled by a ServiceWorker");
+}
+
+navigator.serviceWorker.getRegistration().then(function(reg) {
+  function showWaitingMessage() {
+    console.log("A new ServiceWorker is waiting to become active. It can't become active now because pages are still open that are controlled by the older version. Either close those tabs, or shift+reload them (which loads them without the ServiceWorker). That will allow the new version to become active, so it'll be used for the next page load.");
+  }
+
+  reg.addEventListener('updatefound', function() {
+    console.log("Found a new ServiceWorker!");
+    var installing = reg.installing;
+    reg.installing.addEventListener('statechange', function() {
+      if (installing.state == 'installed') {
+        console.log("New ServiceWorker installed.");
+        // give it a second to see if it activates immediately
+        setTimeout(function() {
+          if (installing.state == 'activated') {
+            console.log("New ServiceWorker activated! Reload to load this page with the new ServiceWorker.");
+          }
+          else {
+            showWaitingMessage();
+          }
+        }, 1000);
+      }
+      else if (installing.state == 'redundant') {
+        console.log("The new worker failed to install - likely an error during install");
+      }
+    });
+  });
+
+  if (reg.waiting) {
+    showWaitingMessage();
+  }
+});

--- a/public/reset-service-worker/index.html
+++ b/public/reset-service-worker/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Reset ServiceWorker</title>
+    <link rel="stylesheet" href="../assets/app.css" />
+  </head>
+  <body>
+    <h1>Resetting ServiceWorker</h1>
+    <script>
+      (function() {
+        if (/reset$/.test(location.pathname)) {
+          location.href = 'reset/';
+          return;
+        }
+        function log(msg) {
+          var p = document.createElement('p');
+          p.textContent = msg;
+          document.body.appendChild(p);
+        }
+        // Let's register our serviceworker
+        navigator.serviceWorker.getRegistration('../').then(function(reg) {
+          log('Unregistering ServiceWorker');
+          return reg && reg.unregister();
+        }).then(function() {
+          return navigator.serviceWorker.getRegistration();
+        }).then(function(reg) {
+          return reg && reg.unregister();
+        }).then(function(reg) {
+          log('Clearing caches');
+          return navigator.serviceWorker.register('sw.js', {
+            scope: './'
+          })
+        }).then(function(reg) {
+          reg.addEventListener('updatefound', function() {
+            var installing = reg.installing;
+            reg.installing.addEventListener('statechange', function() {
+              if (installing.state == 'installed') {
+                log('Done!');
+                reg.unregister();
+              }
+            });
+          });
+        });
+      }());
+    </script>
+  </body>
+</html>

--- a/public/reset-service-worker/sw.js
+++ b/public/reset-service-worker/sw.js
@@ -1,0 +1,12 @@
+self.addEventListener('install', function(event) {
+  // delete all the caches
+  event.waitUntil(
+    caches.keys().then(function(keys) {
+      return Promise.all(
+        keys.map(function(key) {
+          return caches.delete(key);
+        })
+      );
+    })
+  );
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,51 @@
+var urlsToCache = [
+  '/',
+  'assets/js/account.js',
+  'assets/js/common.js',
+  'assets/js/index.js',
+  'assets/app.css',
+  'hoodie/client.js',
+  'logging.js',
+  'about.html',
+  'account.html'
+];
+
+// Add here everything that needs to be done as the ServiceWorker
+// install.
+// The installation only happens once, when the browsers sees this
+// version of the ServiceWorker for the first time.
+self.addEventListener('install', function(event) {
+  // Make sure that new versions of the ServiceWorker are activated
+  // inmediately, without waiting for page reload.
+  event.waitUntil(self.skipWaiting());
+  // Open a cache to store the needed assets
+  event.waitUntil(
+    caches.open('simple-sw-v1').then(function(cache) {
+      return cache.addAll(urlsToCache);
+    })
+  );
+});
+
+
+// The fetch event happens for the page request with the
+// ServiceWorker's scope, and any request made within that
+// page.
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    // Is there something in the cache that matches the request?
+    // Return it!
+    // Otherwise pass the request to the request to `fetch`,
+    // which will use the network.
+    caches.match(event.request).then(function(response) {
+      return response || fetch(event.request);
+    })
+  );
+});
+
+// The activate event happens when a new ServiceWorker is activated,
+// by default when loading a new page or reloading an existent one.
+self.addEventListener('activate', function(event) {
+  // Make sure that new versions of the ServiceWorker are used for
+  // all tabs inmediately, without the need of reload
+  event.waitUntil(self.clients.claim());
+});


### PR DESCRIPTION
WIP! not ready to be merged.

A first draft to add service workers to allow offline caching of assets.

Based in https://github.com/jakearchibald/simple-serviceworker-tutorial, many things directly copied ;-).

The important part is the registration of the service worker in `index.html` (can be moved to it's own file) and the service worker itself `public/sw.js`. As far as I understand, the `sw.js` has to be placed on the root, to be able to cache all urls (if stored in `assets/js` it would only be able to cache files under `assets/js/`). 

For testing purposes there is a `/reset-service-worker` route (that only works online) to get rid of all the service workers and caches.

There is also a logger `logging.js` to better understand what is happening (logs to the console).

As I said, veery rough state, more to show how service worker work. 