### PR TITLE
Dockerize hoodie-app-tracker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-sudo: false
+sudo: required
 language: node_js
 notifications:
   email: false
 services:
-  - couchdb
+  - docker
 # https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-%28or-io.js-v3%29-compiler-requirements
 addons:
   apt:
@@ -14,6 +14,9 @@ addons:
 node_js:
   - 4
 before_install:
+  - docker version
+  - docker run -d -p 127.0.0.1:5984:5984 klaemo/couchdb:1.6.1
+  - docker build -t hoodiehq/hoodie-app-tracker .
   - npm install --global npm@3
   - npm prune
 before_script:
@@ -28,6 +31,11 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 after_success:
   - npm run semantic-release
+deploy:
+- provider: script
+  script: docker login -e $DOCKER_EMAIL -u $DOCKER_USERNAME -p $DOCKER_PASSWORD && docker push hoodiehq/hoodie-app-tracker
+  on:
+    branch: master
 env:
   global:
     - CXX=g++-4.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM mhart/alpine-node:5
+
+WORKDIR /app
+
+ADD package.json ./
+ADD ./public ./public
+# ADD ./.hoodierc ./
+
+RUN apk add --no-cache git && npm install --production --no-optional && \
+    apk del git && \
+    rm -rf /tmp/* /root/.npm
+
+ENV hoodie_dbUrl http://admin:secret@couchdb:5984/
+
+EXPOSE 8080
+
+CMD ["npm", "start", "--", "--bind-address", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ admin username or password).
 npm start -- --dbUrl=http://admin:secret@localhost:5984
 ```
 
+# Deployment
+
+You can find a detailed instruction [here](deployment.md).
+
 ## Contribute
 
 `hoodie-app-tracker` is work in progress. The goal is to have a simple

--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,87 @@
+# Deployment
+
+## Deploy with Docker
+
+### Start CouchDB
+```shell
+$ docker run -d --name my-couchdb \
+    -v /data/couchdb:/usr/local/var/lib/couchdb \
+    klaemo/couchdb:1.6.1
+$ # create a admin user with the password `secret`
+$ # of course you can use you own username/password
+$ docker run -it --rm \
+    --link my-couchdb:couchdb \
+    yxdhde/alpine-curl-git curl -X PUT \
+    couchdb:5984/_config/admins/admin -d '"secret"'
+$ # login with the admin user
+$ docker run -it --rm \
+    --link my-couchdb:couchdb \
+    yxdhde/alpine-curl-git curl -X POST \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    couchdb:5984/_session -d 'name=admin&password=secret'
+```
+
+### Build hoodie-app-tracker
+```shell
+$ docker build -t hoodie-app-tracker .
+$ docker run -d -p 8080:8080 \
+    --name my-app \
+    --link my-couchdb:couchdb \
+    hoodie-app-tracker
+```
+
+##### Or use the prebuilt Docker image
+```shell
+$ docker run -d -p 8080:8080 \
+    --name my-app \
+    --link my-couchdb:couchdb \
+    -e hoodie_dbUrl=http://admin:secret@couchdb:5984/
+    hoodiehq/hoodie-app-tracker
+```
+
+### Continuous deployment with Docker Hub
+```shell
+$ docker run -d --name hub-webhook \
+    -e VIRTUAL_HOST=webhook-deploy.my-domain.com \
+    -e DEFAULT_PARAMS='--restart=always -p 8080:8080 --link my-couchdb:couchdb' \
+    -e DEFAULT_TOKEN=my-webhook-token \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    christophwitzko/docker-hub-webhook
+```
+
+Set up a webhook on Docker Hub with the URL `http://deploy-webhook.my-domain.com/my-webhook-token`.
+
+## Example with a reverse proxy
+This example is deployed at [tracker.hood.ie](https://tracker.hood.ie).
+
+#### Reverse Proxy with Letsencrypt
+The following two docker commands start a Nginx reverse proxy with automatic certificate creation and renewal.
+```shell
+$ docker run -d -p 80:80 -p 443:443 \
+    --name nginx-proxy \
+    -v /data/certs:/etc/nginx/certs:ro \
+    -v /etc/nginx/vhost.d \
+    -v /usr/share/nginx/html \
+    -v /var/run/docker.sock:/tmp/docker.sock:ro \
+    jwilder/nginx-proxy
+$ docker run -d --name letsencrypt-companion \
+    --volumes-from nginx-proxy \
+    -v /data/certs:/etc/nginx/certs:rw \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    jrcs/letsencrypt-nginx-proxy-companion
+```
+#### Start CouchDB
+This step is equivalent to [Start CouchDB](#start-couchdb).
+
+#### Docker Hub webhook deployment
+This starts the webhook server. If it receives a webhook it pulls the updated image and restarts the container. More info [here](https://github.com/christophwitzko/docker-hub-webhook).
+```shell
+$ docker run -d --name hub-webhook \
+    -e VIRTUAL_HOST=webhook-deploy.hood.ie \
+    -e LETSENCRYPT_HOST=webhook-deploy.hood.ie \
+    -e LETSENCRYPT_EMAIL=your@email.com \
+    -e DEFAULT_PARAMS='--restart=always -e hoodie_dbUrl=http://admin:secret@couchdb:5984/ -e VIRTUAL_HOST=tracker.hood.ie -e LETSENCRYPT_HOST=tracker.hood.ie -e LETSENCRYPT_EMAIL=your@email.com --link my-couchdb:couchdb' \
+    -e DEFAULT_TOKEN=my-secret-token \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    christophwitzko/docker-hub-webhook
+```


### PR DESCRIPTION
This PR adds Docker support for `hoodie-app-tracker`. :whale:

If code gets pushed to the `master` branch a new Docker image will be built and pushed to [Docker Hub](https://hub.docker.com/r/hoodiehq/hoodie-app-tracker/).

## Deployment
If the image was successfully pushed to [Docker Hub](https://hub.docker.com/r/hoodiehq/hoodie-app-tracker/) a [Docker Hub webhook](https://docs.docker.com/docker-hub/webhooks/) triggers the deployment process. On the server runs a [webhook receiver](https://github.com/christophwitzko/docker-hub-webhook), which pulls the updated image and restarts the container. More info [here](https://github.com/hoodiehq/hoodie-app-tracker/blob/dockerize-app/README.md#continuous-deployment-with-docker-hub).