### PR TITLE
fix: increase toucharea of table links

### DIFF
--- a/public/assets/app.css
+++ b/public/assets/app.css
@@ -370,6 +370,12 @@ table tr td:nth-child(2) {
   width: 300px;
 }
 
+table td > a {
+  display: block;
+  padding: 1rem;
+  margin: -1rem;
+}
+
 img.hoodie-camp {
   max-width: 100%;
 }


### PR DESCRIPTION
Little optimisation, make the touch areas inside the table nice and big.

(Red background used to see the difference)
![image](https://cloud.githubusercontent.com/assets/2445413/13731086/ef5f7fa8-e958-11e5-947c-805f6dc94cef.png)
