### PR TITLE
fix: add missing chai devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@gr2m/frontend-test-setup": "^1.1.3",
+    "chai": "^3.5.0",
     "mocha": "^2.3.4",
     "semantic-release": "^6.0.3",
     "standard": "^6.0.7"


### PR DESCRIPTION
The tests failed for me because the `chai` dependency was not listed in the `devDependencies`. I added it to the list.