### PR TITLE
clear items on signout

### DIFF
--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -17,6 +17,9 @@ loadAndRenderItems()
  * Anytime there is a data change we reload and render the list of items
  */
 hoodie.store.on('change', loadAndRenderItems)
+hoodie.store.on('clear', function () {
+  render([])
+})
 
 $clearButton.addEventListener('click', function () {
   hoodie.store.removeAll()


### PR DESCRIPTION
when running `hoodie.account.signOut()` in the browser console, the items table does not get cleared at the moment, as no `remove` events are emitted on signout, but a single `clear` event