### PR TITLE
Deploy with now

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pretest": "standard test/**/*.js",
     "test": "frontend-test-background mocha test/*.js",
     "start": "hoodie",
+    "now-start": "hoodie --inMemory",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {


### PR DESCRIPTION
the `now-start` script will be used when the app is deployed with https://zeit.co/now.
No data is persisted, but this is great for quick testing. We could for example quickly
spawn an instance for a pull-request, so we can test it manually before merging :)
