### PR TITLE
Fixed IE11 issues with CSS selectors for data attributes 

### DIFF
--- a/public/assets/js/account.js
+++ b/public/assets/js/account.js
@@ -18,11 +18,11 @@ var locationHash = window.location.hash.replace('#', '')
 
     event.preventDefault()
     var showTarget = action.substr('show-'.length)
-    $formsContainer.dataset.show = showTarget
+    $formsContainer.setAttribute('data-show', showTarget)
     setHashState(showTarget)
   })
   if (locationHash) {
-    el.dataset.show = locationHash
+    el.setAttribute('data-show', locationHash)
     setHashState(locationHash)
   }
 })
@@ -102,7 +102,7 @@ document.querySelector('form.password-reset').addEventListener('submit', functio
 
   .then(function () {
     alert('Email sent to ' + email)
-    document.querySelector('[data-show="password-reset"]').dataset.show = 'signin'
+    document.querySelector('[data-show="password-reset"]').setAttribute('data-show', 'signin')
     setHashState('signin')
   })
 

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -97,11 +97,11 @@ $itemsList.addEventListener('click', function (event) {
 
 function render (items) {
   if (items.length === 0) {
-    document.body.dataset.storeState = 'empty'
+    document.body.setAttribute('data-store-state', 'empty')
     return
   }
 
-  document.body.dataset.storeState = 'not-empty'
+  document.body.setAttribute('data-store-state', 'not-empty')
   $itemsList.innerHTML = items
     .sort(orderByCreatedAt)
     .map(function (item) {


### PR DESCRIPTION
This should fix one of the issues in #19.

The problem is described (and demonstrated) here: https://github.com/niloy/blog/issues/20

I found out that the bug doesn't occur when we call `element.setAttribute` instead of assigning a  `element.dataset` value. Reading the dataset value still works afterwards.

closes #19