### PR TITLE
I added sign out button that hides when user is not logged in.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,9 @@
           Clear tracked items
         </button>
       </div>
+      <div class="signout-container">
+        <button class="small"  data-hide-if="signed-out" data-action="signout">Sign out</button>
+      </div>
     </main>
 
     <script src="/hoodie/client.js"></script>


### PR DESCRIPTION
There was an issue where once user logged in to log  out he had to go to profile and click sign out button, I added that button to index page, and copied hide if not signed in custom element into button. 
css works, hide in if not signed in works, but actual sign out feature of the button doesn't work itself.