### PR TITLE
Changed sign out button position to the top of the page

### DIFF
--- a/public/account.html
+++ b/public/account.html
@@ -20,6 +20,11 @@
             </a>
           </li>
           <li><a href="about.html">about</a></li>
+          <li>
+            <div class="signout-container">
+               <button class="small" data-hide-if="signed-out" data-action="signout">Sign out</button>
+            </div>
+          </li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
I moved sign out button from the bottom to the top inside `<ul>` after `about` link. It helps user to see `logout` button right after his username.