### PR TITLE
fix: hoodie is not defined

### DIFF
--- a/test/connection-status-test.js
+++ b/test/connection-status-test.js
@@ -32,7 +32,11 @@ describe('hoodie.connectionStatus', function () {
   this.timeout(90000)
 
   beforeEach(function () {
-    return this.client.url('/')
+    var client = this.client
+
+    return client.url('/').then(function () {
+      return client.url('/')
+    })
 
     // keep track of events for tests
     .execute(function setEvents () {


### PR DESCRIPTION
Work around Chrome bug where `hoodie` is not defined on first load.

Closes #106.
