### PR TITLE
chore: adding now.json to allow deployment on zeit's now service closes: #174

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,4 @@
+{
+  "alias": "hoodie-app-tracker",
+  "type": "npm"
+}


### PR DESCRIPTION
Should mean future commits to master will automatically update here: [https://hoodie-app-tracker.now.sh/](https://hoodie-app-tracker.now.sh/). Need to update Default Hoodie App url to point to this on github hoodie-app-tracker page? 


